### PR TITLE
change download url to download=0

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -100,7 +100,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
             elements.forEach(function (element) {
                 let name = isSeries ? getSEname(element) + ' - ' + element.title : element.title;
                 newElement = {
-                    url: [serverUrl, element.Media[0].Part[0].key, "?X-Plex-Token=", token, "&download=1"].join(""),
+                    url: [serverUrl, element.Media[0].Part[0].key, "?X-Plex-Token=", token, "&download=0"].join(""),
                     path: path,
                     filename: escapeWinPath(name + "." + element.Media[0].container, false)
                 };


### PR DESCRIPTION
Hi, 
I am not 100% sure what is the reason for this, but i found that the link how it was in the plugin right now is not working.
However, if we set the GET Param `download` from 1 to 0 it is working again. 

Hope this helps and we can get this PR merged :-) 